### PR TITLE
replaced all f64s in graphics with f32

### DIFF
--- a/src/graphics/common.rs
+++ b/src/graphics/common.rs
@@ -1,6 +1,6 @@
 pub struct Vec2 {
-    pub x: f64,
-    pub y: f64,
+    pub x: f32,
+    pub y: f32,
 }
 
 pub enum Direction {

--- a/src/graphics/element.rs
+++ b/src/graphics/element.rs
@@ -1,13 +1,13 @@
-use crate::graphics::style::*;
+use crate::graphics::{Vec2, style::*};
 
 pub enum Element {
     Line {
-        points: Vec<(f64, f64)>,
+        points: Vec<Vec2>,
         stroke: StrokeStyle,
     },
     Rect {
-        pos: (f64, f64),
-        size: (f64, f64),
+        pos: Vec2,
+        size: Vec2,
         stroke: StrokeStyle,
         fill: FillStyle,
     },


### PR DESCRIPTION
f32 is accurate to 7 decimal places, for graphics purposes, thats within a hundredth of a pixel even if we have an 8k screen